### PR TITLE
prevent okhttp post with null body

### DIFF
--- a/src/main/java/me/tomsdevsn/hetznercloud/HetznerCloudAPI.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/HetznerCloudAPI.java
@@ -2447,7 +2447,7 @@ public class HetznerCloudAPI {
     }
 
     private <T> T post(String url, Class<T> clazz) {
-        return exchange(url, HttpMethod.POST, null, clazz);
+        return exchange(url, HttpMethod.POST, objectMapper.createObjectNode(), clazz);
     }
 
     private enum HttpMethod {


### PR DESCRIPTION
Okhttp doesn't let to send post requests with null body, and also the body (with empty json object) is required by hetzner cloud api.

Your latest changes (migrating to okhttp) broke our automation tool, all post requests with null body are broken right now, like reset-server request and so on...

Passing empty json object whenever the body is null did the trick cause it's required by both okhttp and hetzner cloud api.