### PR TITLE
add support for 'server_error' server status

### DIFF
--- a/src/main/java/me/tomsdevsn/hetznercloud/objects/general/APIErrorCode.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/objects/general/APIErrorCode.java
@@ -61,7 +61,8 @@ public enum APIErrorCode {
     server_has_ipv6,
     primary_ip_already_assigned,
     server_is_load_balancer_target,
-
+    server_error,
+    
     //Server related
     placement_error,
     primary_ip_assigned,


### PR DESCRIPTION
There seems to be a (maybe new) API error code being returned form the Hetzner API. 

```
etzner api request failed 'com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `me.tomsdevsn.hetznercloud.objects.general.APIErrorCode` from String "server_error": not one of the values accepted for Enum class: [invalid_input, ca_too_many_duplicate_certificates, load_balancer_not_attached_to_network, locked, ca_dns_validation_failed, networks_overlap, could_not_verify_domain_delegated_to_zone, firewall_managed_by_label_selector, caa_record_does_not_allow_ca, not_found, dns_zone_not_found, load_balancer_already_attached, source_port_already_used, resource_unavailable, ip_not_owned, no_subnet_available, ca_too_many_certificates_issued_for_registered_domain, server_already_attached, resource_limit_exceeded, primary_ip_assigned, protected, _protected, primary_ip_already_assigned, uniqueness_error, firewall_already_removed, resource_in_use, firewall_resource_not_found, ip_not_available, token_readonly, dns_zone_is_secondary_zone, conflict, primary_ip_datacenter_mismatch, firewall_already_applied, ca_too_many_authorizations_failed_recently, server_already_added, server_not_stopped, server_has_ipv4, server_has_ipv6, cloud_resource_ip_not_allowed, invalid_server_type, incompatible_network_type, invalid_load_balancer_type, target_already_defined, forbidden, server_is_load_balancer_target, robot_unavailable, server_not_attached_to_network, unsupported_error, maintenance, rate_limit_exceeded, no_space_left_in_location, primary_ip_version_mismatch, targets_without_use_private_ip, json_error, service_error, placement_error]
 at [Source: (String)"{
  "error": {
    "message": null,
    "code": "server_error",
    "details": null
  }
}
"; line: 4, column: 13] (through reference chain: me.tomsdevsn.hetznercloud.objects.response.APIErrorResponse["error"]->me.tomsdevsn.hetznercloud.objects.general.APIError["code"])'
java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `me.tomsdevsn.hetznercloud.objects.general.APIErrorCode` from String "server_error": not one of the values accepted for Enum class: [invalid_input, ca_too_many_duplicate_certificates, load_balancer_not_attached_to_network, locked, ca_dns_validation_failed, networks_overlap, could_not_verify_domain_delegated_to_zone, firewall_managed_by_label_selector, caa_record_does_not_allow_ca, not_found, dns_zone_not_found, load_balancer_already_attached, source_port_already_used, resource_unavailable, ip_not_owned, no_subnet_available, ca_too_many_certificates_issued_for_registered_domain, server_already_attached, resource_limit_exceeded, primary_ip_assigned, protected, _protected, primary_ip_already_assigned, uniqueness_error, firewall_already_removed, resource_in_use, firewall_resource_not_found, ip_not_available, token_readonly, dns_zone_is_secondary_zone, conflict, primary_ip_datacenter_mismatch, firewall_already_applied, ca_too_many_authorizations_failed_recently, server_already_added, server_not_stopped, server_has_ipv4, server_has_ipv6, cloud_resource_ip_not_allowed, invalid_server_type, incompatible_network_type, invalid_load_balancer_type, target_already_defined, forbidden, server_is_load_balancer_target, robot_unavailable, server_not_attached_to_network, unsupported_error, maintenance, rate_limit_exceeded, no_space_left_in_location, primary_ip_version_mismatch, targets_without_use_private_ip, json_error, service_error, placement_error]
 at [Source: (String)"{
  "error": {
    "message": null,
    "code": "server_error",
    "details": null
  }
}
"; line: 4, column: 13] (through reference chain: me.tomsdevsn.hetznercloud.objects.response.APIErrorResponse["error"]->me.tomsdevsn.hetznercloud.objects.general.APIError["code"])
	at me.tomsdevsn.hetznercloud.HetznerCloudAPI.exchange(HetznerCloudAPI.java:2482)
	at me.tomsdevsn.hetznercloud.HetznerCloudAPI.post(HetznerCloudAPI.java:2514)
	at me.tomsdevsn.hetznercloud.HetznerCloudAPI.createServer(HetznerCloudAPI.java:180)
```