### PR TITLE
allow to provide certificate type to enable creation of hetzner manag…

### DIFF
--- a/src/main/java/me/tomsdevsn/hetznercloud/objects/enums/CertificateType.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/objects/enums/CertificateType.java
@@ -1,0 +1,5 @@
+package me.tomsdevsn.hetznercloud.objects.enums;
+
+public enum CertificateType {
+    uploaded, managed
+}

--- a/src/main/java/me/tomsdevsn/hetznercloud/objects/general/Certificate.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/objects/general/Certificate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 import me.tomsdevsn.hetznercloud.deserialize.DateDeserializer;
+import me.tomsdevsn.hetznercloud.objects.enums.CertificateType;
 
 import java.util.Date;
 import java.util.List;
@@ -29,6 +30,7 @@ public class Certificate {
     private String fingerprint;
     @JsonProperty("used_by")
     private List<CertificateUsers> usedBy;
+    private CertificateType type;
 
     @Data
     public static class CertificateUsers {

--- a/src/main/java/me/tomsdevsn/hetznercloud/objects/request/CreateCertificateRequest.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/objects/request/CreateCertificateRequest.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Singular;
+import me.tomsdevsn.hetznercloud.objects.enums.CertificateType;
 
 import java.util.List;
 import java.util.Map;
@@ -24,4 +25,5 @@ public class CreateCertificateRequest {
     private String privateKey;
     @Singular
     private Map<String, String> labels;
+    private CertificateType type;
 }


### PR DESCRIPTION
this changes allows the user to request a hetzner managed certificate. integration tests are not feasible in this case because it would require a working hetzner DNS setup