### PR TITLE
servertype: add getServerTypes paginated

### DIFF
--- a/src/main/java/me/tomsdevsn/hetznercloud/HetznerCloudAPI.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/HetznerCloudAPI.java
@@ -1264,6 +1264,20 @@ public class HetznerCloudAPI {
     }
 
     /**
+     * Get Server types Paginated.
+     *
+     * @return ServerTypesResponse object
+     */
+    public ServerTypesResponse getServerTypes(PaginationParameters paginationParameters) {
+        return get(
+                UrlBuilder.from(API_URL + "/server_types")
+                        .queryParamIfPresent("page", Optional.ofNullable(paginationParameters.page))
+                        .queryParamIfPresent("per_page", Optional.ofNullable(paginationParameters.perPage))
+                        .toUri(),
+                ServerTypesResponse.class);
+    }
+
+    /**
      * Get all Load Balancer types.
      *
      * @return LoadBalancerTypesResponse object


### PR DESCRIPTION
To fetch more than the default 25 server types

https://docs.hetzner.cloud/#server-types-get-all-server-types