### PR TITLE
readme: change docs path to github url

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ HCLOUD_TOKEN="${api_key}" mvn test
 
 ## JavaDocs
 
-The JavaDocs are available [here](https://docs.hcloud.siewert.io)
+The JavaDocs are available [here](https://tomsiewert.github.io/hetznercloud-java/)
 
 ## Dependencies
 


### PR DESCRIPTION
Some time ago I removed docs.hcloud.siewert.io because it was very legacy.