### PR TITLE
add missing api error codes

### DIFF
--- a/src/main/java/me/tomsdevsn/hetznercloud/objects/general/APIErrorCode.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/objects/general/APIErrorCode.java
@@ -21,7 +21,9 @@ public enum APIErrorCode {
     conflict,
     unsupported_error,
     token_readonly,
-
+    unavailable,
+    unauthorized,
+    
     //Certificate related
     caa_record_does_not_allow_ca,
     ca_dns_validation_failed,


### PR DESCRIPTION
According to the Hetzner Cloud API documentation, these two API error codes were missing, which caused the errors in our app.

[https://docs.hetzner.cloud/#errors](https://docs.hetzner.cloud/#errors)

**unavailable** | A service or product is currently not available
**unauthorized** | Request was made with an invalid or unknown token