### PR TITLE
Makes Price class public

### DIFF
--- a/src/main/java/me/tomsdevsn/hetznercloud/objects/pricing/Price.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/objects/pricing/Price.java
@@ -3,7 +3,7 @@ package me.tomsdevsn.hetznercloud.objects.pricing;
 import lombok.Data;
 
 @Data
-class Price {
+public class Price {
 
     private Double net;
     private Double gross;


### PR DESCRIPTION
Hello :wave:,

Thanks for this repo !

I'm currently trying to get prices for each server type. When I try to do so with version `3.2.6` it seems that `Price` is not accessible.

If that's not normal here is a simple change to make Price public.

![image](https://github.com/user-attachments/assets/c696fae8-1495-4b6a-a4e2-ebb5dbffb149)

