### PR TITLE
Add missing firewalls to PublicNet

### DIFF
--- a/src/main/java/me/tomsdevsn/hetznercloud/objects/general/PublicNet.java
+++ b/src/main/java/me/tomsdevsn/hetznercloud/objects/general/PublicNet.java
@@ -12,6 +12,7 @@ public class PublicNet {
     private IPv6 ipv6;
     @JsonProperty("floating_ips")
     private List<Long> floatingIPs;
+    private List<Firewall> firewalls;
 
     @Data
     public static class IPv4 {
@@ -29,5 +30,11 @@ public class PublicNet {
         private boolean blocked;
         @JsonProperty("dns_ptr")
         private List<DnsPTR> dnsPTR;
+    }
+
+    @Data
+    public static class Firewall {
+        private Long id;
+        private String status;
     }
 }


### PR DESCRIPTION
Firewalls are missing from the response associated with servers. This PR adds them